### PR TITLE
tmux: add clickable [+] new-tab button to status bar

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -150,3 +150,11 @@ bind -n MouseDown1StatusRight if -F '#{==:#{mouse_status_range},newtab}' 'new-wi
 
 # Clicking/tapping empty status-bar space also opens a new window
 bind -n MouseDown1StatusDefault new-window -c "#{pane_current_path}"
+
+# ---------------------------------------------------------------------------
+# Double-height status bar — easier tap targets on phone/tablet
+# ---------------------------------------------------------------------------
+# Second status line mirrors the first, so every window tab and the [+]
+# button is two rows tall. Clickable ranges work on both lines.
+set -g status 2
+set -g status-format[1] "#{T:status-format[0]}"

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -140,3 +140,13 @@ set -g @continuum-save-interval '15'
 # Initialize TPM (keep at bottom)
 # ---------------------------------------------------------------------------
 run '~/.config/tmux/plugins/tpm/tpm'
+
+# ---------------------------------------------------------------------------
+# Status-line "new tab" button (after TPM so plugins can't clobber it)
+# ---------------------------------------------------------------------------
+# Clickable [+] at the right edge of the status bar (needs tmux >= 3.4)
+set -ga status-right "#[range=user|newtab]#[fg=magenta,bold] [+] #[default]#[norange]"
+bind -n MouseDown1StatusRight if -F '#{==:#{mouse_status_range},newtab}' 'new-window -c "#{pane_current_path}"'
+
+# Clicking/tapping empty status-bar space also opens a new window
+bind -n MouseDown1StatusDefault new-window -c "#{pane_current_path}"

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -156,5 +156,8 @@ bind -n MouseDown1StatusDefault new-window -c "#{pane_current_path}"
 # ---------------------------------------------------------------------------
 # Second status line mirrors the first, so every window tab and the [+]
 # button is two rows tall. Clickable ranges work on both lines.
-set -g status 2
+# Only enabled for narrow clients (phones): status height is session-wide,
+# so hooks toggle it based on the width of whichever client attaches/resizes.
 set -g status-format[1] "#{T:status-format[0]}"
+set-hook -ga client-attached "if -F '#{e|<:#{client_width},100}' 'set -g status 2' 'set -g status on'"
+set-hook -ga client-resized  "if -F '#{e|<:#{client_width},100}' 'set -g status 2' 'set -g status on'"


### PR DESCRIPTION
Adds two mouse-driven ways to open a new tmux window ("tab"), aimed at using Blink + mosh from an iPad where taps are forwarded to tmux as mouse clicks:

- A clickable `[+]` button at the right edge of the status bar, implemented with a `#[range=user|newtab]` status-line region and a `MouseDown1StatusRight` binding that checks `#{mouse_status_range}`. Requires tmux >= 3.4 on the server.
- A `MouseDown1StatusDefault` binding so tapping any empty area of the status bar also opens a new window (works on older tmux too).

Both open the new window in the current pane's working directory, matching the existing split bindings. Placed after the TPM init line so catppuccin/plugins can't override `status-right`.

https://claude.ai/code/session_01CYCJ7PfkozhSKZLk1ySiri

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYCJ7PfkozhSKZLk1ySiri)_